### PR TITLE
인증실패 페이지 퍼블리싱:

### DIFF
--- a/presentation/src/main/res/drawable/lg_authentication_failed_icon.xml
+++ b/presentation/src/main/res/drawable/lg_authentication_failed_icon.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="88dp"
+    android:height="88dp"
+    android:viewportWidth="88"
+    android:viewportHeight="88">
+  <path
+      android:pathData="M44,44m-44,0a44,44 0,1 1,88 0a44,44 0,1 1,-88 0"
+      android:fillColor="#F1F1F5"/>
+  <path
+      android:pathData="M44,23.76V45.76M44,63.36H44.047V63.407H44V63.36Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="10"
+      android:fillColor="#00000000"
+      android:strokeColor="#42CC89"
+      android:strokeLineCap="round"/>
+</vector>

--- a/presentation/src/main/res/layout/activity_authentication_failed_page.xml
+++ b/presentation/src/main/res/layout/activity_authentication_failed_page.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_authentication_failed_t"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.316" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_authentication_failed_b"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.432" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_authentication_failed_s"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.422" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_authentication_failed_e"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.579" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_authentication_failed_text_t"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.475" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_authentication_failed_text_b"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.52" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_authentication_failed_text_s"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.427" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_authentication_failed_text_e"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.574" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_go_back_to_login_page_btn_s"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.094" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_go_back_to_login_page_btn_e"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.906" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_go_back_to_login_page_btn_t"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.86" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_go_back_to_login_page_btn_b"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.932" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_try_again_text_t"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.525" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/g_try_again_text_b"
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.553" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:id="@+id/g_try_again_text_s"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.4"
+        />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:id="@+id/g_try_again_text_e"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.599"
+        />
+
+    <ImageView
+        android:id="@+id/iv_authentication_failed_icon"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/lg_authentication_failed_icon"
+        app:layout_constraintBottom_toBottomOf="@id/g_authentication_failed_b"
+        app:layout_constraintEnd_toEndOf="@id/g_authentication_failed_e"
+        app:layout_constraintStart_toStartOf="@id/g_authentication_failed_s"
+        app:layout_constraintTop_toTopOf="@id/g_authentication_failed_t" />
+
+    <TextView
+        android:id="@+id/tv_authentication_failed"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fontFamily="@font/pretendard_bold"
+        android:text="@string/authentication_failed"
+        android:textColor="@color/black"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="@id/g_authentication_failed_text_e"
+        app:layout_constraintStart_toStartOf="@id/g_authentication_failed_text_s"
+        app:layout_constraintTop_toTopOf="@id/g_authentication_failed_text_t"
+        app:layout_constraintBottom_toBottomOf="@id/g_authentication_failed_text_b"
+        />
+
+    <TextView
+        android:id="@+id/tv_try_again"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fontFamily="@font/pretendard_regular"
+        android:text="@string/try_again"
+        android:textSize="15sp"
+        app:layout_constraintEnd_toEndOf="@id/g_try_again_text_e"
+        app:layout_constraintStart_toStartOf="@id/g_try_again_text_s"
+        app:layout_constraintTop_toTopOf="@+id/g_try_again_text_t"
+        app:layout_constraintBottom_toBottomOf="@id/g_try_again_text_b"
+        />
+
+
+    <Button
+        android:id="@+id/btn_go_back_to_login_page"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="@drawable/btn_login"
+        android:fontFamily="@font/pretendard_semibold"
+        android:text="@string/go_back_to_login_page"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="@id/g_go_back_to_login_page_btn_b"
+        app:layout_constraintEnd_toEndOf="@id/g_go_back_to_login_page_btn_e"
+        app:layout_constraintStart_toStartOf="@id/g_go_back_to_login_page_btn_s"
+        app:layout_constraintTop_toTopOf="@id/g_go_back_to_login_page_btn_t" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/presentation/src/main/res/layout/activity_authentication_success_page.xml
+++ b/presentation/src/main/res/layout/activity_authentication_success_page.xml
@@ -4,33 +4,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/g_ibtn_back_button_t"
-        android:layout_width="match_parent"
-        android:layout_height="0.5dp"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.075" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/g_ibtn_back_button_b"
-        android:layout_width="match_parent"
-        android:layout_height="0.5dp"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_percent="0.102" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/g_ibtn_back_button_s"
-        android:layout_width="match_parent"
-        android:layout_height="0.5dp"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.017" />
-
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/g_ibtn_back_button_e"
-        android:layout_width="match_parent"
-        android:layout_height="0.5dp"
-        android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.043" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/g_iv_authentication_success_icon_s"
@@ -143,16 +116,6 @@
         android:layout_height="0.5dp"
         android:orientation="horizontal"
         app:layout_constraintGuide_percent="0.932" />
-
-    <ImageButton
-        android:id="@+id/ibtn_back_button"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:background="@drawable/ibtn_back_button"
-        app:layout_constraintBottom_toBottomOf="@id/g_ibtn_back_button_b"
-        app:layout_constraintEnd_toEndOf="@id/g_ibtn_back_button_e"
-        app:layout_constraintStart_toStartOf="@id/g_ibtn_back_button_s"
-        app:layout_constraintTop_toTopOf="@id/g_ibtn_back_button_t" />
 
     <ImageView
         android:id="@+id/iv_authentication_success_icon"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -19,4 +19,6 @@
     <string name="go_back_to_login_page">로그인으로 돌아가기</string>
     <string name="authentication_success">인증성공!</string>
     <string name="success_to_email_authentication">이메일 인증에 성공하였습니다.</string>
+    <string name="authentication_failed">인증실패</string>
+    <string name="try_again">다시 시도해주세요.</string>
 </resources>


### PR DESCRIPTION
## 💡 개요
인증실패 페이지 퍼블리싱
## 📃 작업내용
인증에 실패했을때 나오는 인증실패 페이지를 퍼블리싱 했습니다.
## 🔀 변경사항
인증성공 페이지의 뒤로가기 버튼을 삭제했습니다.
## 🙋‍♂️ 질문사항
제가 빠뜨린 가이드라인 적용이나 너 효율적인 구현 방법이 있다면 알려주세요!
## 🍴 사용방법

## 🎸 기타
