### PR TITLE
🔀 :: (#46) - token save to local with sharedpreference

### DIFF
--- a/data/src/main/java/com/team_ia/data/local/datasource/LocalAuthDataSource.kt
+++ b/data/src/main/java/com/team_ia/data/local/datasource/LocalAuthDataSource.kt
@@ -1,0 +1,8 @@
+package com.team_ia.data.local.datasource
+
+interface LocalAuthDataSource {
+    suspend fun getAccessToken(): String?
+    suspend fun getRefreshToken(): String?
+    suspend fun getExpiredAt(): String?
+    suspend fun saveToken(access: String?, refresh: String?,expiredAt: String?)
+}

--- a/data/src/main/java/com/team_ia/data/local/datasource/LocalAuthDataSourceImpl.kt
+++ b/data/src/main/java/com/team_ia/data/local/datasource/LocalAuthDataSourceImpl.kt
@@ -1,0 +1,24 @@
+package com.team_ia.data.local.datasource
+
+import com.team_ia.data.local.storage.AuthStorage
+import javax.inject.Inject
+
+class LocalAuthDataSourceImpl @Inject constructor(
+    private val localStorage: AuthStorage
+): LocalAuthDataSource {
+    override suspend fun getAccessToken(): String? =
+        localStorage.getAccessToken()
+
+    override suspend fun getRefreshToken(): String? =
+        localStorage.getRefreshToken()
+
+    override suspend fun getExpiredAt(): String? =
+        localStorage.getExpiredAt()
+
+    override suspend fun saveToken(access: String?, refresh: String?, expiredAt: String?) =
+        localStorage.run {
+            setAccessToken(access)
+            setRefreshToken(refresh)
+            setExpiredAt(expiredAt)
+        }
+}

--- a/data/src/main/java/com/team_ia/data/local/storage/AuthStorage.kt
+++ b/data/src/main/java/com/team_ia/data/local/storage/AuthStorage.kt
@@ -1,0 +1,12 @@
+package com.team_ia.data.local.storage
+
+interface AuthStorage {
+    fun setAccessToken(access: String?)
+    fun getAccessToken(): String?
+
+    fun setRefreshToken(refresh: String?)
+    fun getRefreshToken(): String?
+
+    fun setExpiredAt(expiredAt: String?)
+    fun getExpiredAt(): String?
+}

--- a/data/src/main/java/com/team_ia/data/local/storage/AuthStorageImpl.kt
+++ b/data/src/main/java/com/team_ia/data/local/storage/AuthStorageImpl.kt
@@ -1,0 +1,37 @@
+package com.team_ia.data.local.storage
+
+import android.content.SharedPreferences
+import javax.inject.Inject
+
+class AuthStorageImpl @Inject constructor(
+    private val sharedPreferences: SharedPreferences
+) : AuthStorage {
+    companion object {
+        const val TOKEN = "TOKEN"
+        const val ACCESS_TOKEN = "ACCESS_TOKEN"
+        const val REFRESH_TOKEN = "REFRESH_TOKEN"
+        const val EXPIRED_AT = "EXPIRED_AT"
+    }
+
+    override fun setAccessToken(access: String?) =
+        setData(ACCESS_TOKEN, access)
+    override fun getAccessToken(): String? =
+        sharedPreferences.getString(ACCESS_TOKEN, "")
+
+    override fun setRefreshToken(refresh: String?) =
+        setData(REFRESH_TOKEN, refresh)
+    override fun getRefreshToken(): String? =
+        sharedPreferences.getString(REFRESH_TOKEN, "")
+
+    override fun setExpiredAt(expiredAt: String?) =
+        setData(EXPIRED_AT, expiredAt)
+    override fun getExpiredAt(): String? =
+        sharedPreferences.getString(EXPIRED_AT, "")
+
+    private fun setData(id: String, data: String?) {
+        sharedPreferences.edit().let {
+            it.putString(id, data)
+            it.apply()
+        }
+    }
+}

--- a/di/src/main/java/com/team_ia/di/SharedPreferenceModule.kt
+++ b/di/src/main/java/com/team_ia/di/SharedPreferenceModule.kt
@@ -1,0 +1,20 @@
+package com.team_ia.di
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.preference.PreferenceManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+
+
+@Module
+@InstallIn(SingletonComponent::class)
+class SharedPreferenceModule {
+    @Provides
+    fun provideSharedPreference(
+        @ApplicationContext context: Context
+    ): SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+}


### PR DESCRIPTION
## 💡 개요
토큰을 로컬에 저장하는 기능 구현
## 📃 작업내용
sharedpreference를 사용하여 local 패키지 안에 기능을 구현하였습니다
## 🔀 변경사항
di에 sharedpreferenceModule을 추가하였습니다
local 패키지 안에 datasource 패키지를 생성하여 LocalDataSource, LocalDataSourceImpl을 추가 하였고
storage 패키지를 만들어 AuthStorage, AuthStorageImpl을 만들어 추가하였습니다
## 🙋‍♂️ 질문사항

## 🍴 사용방법

## 🎸 기타
